### PR TITLE
feat: support BRAGDOC_HOME env var for data directory

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,2 @@
+# Isolates dev data from the official bragdoc install (~/.bragdoc)
+export BRAGDOC_HOME="$PWD/.bragdoc"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,7 @@ This project adheres to a code of conduct that all contributors are expected to 
 - **Go 1.21.1** or higher
 - **Make** (for build automation)
 - **Git** (for version control)
+- **direnv** (recommended, for environment isolation)
 
 ### Install Dependencies
 
@@ -47,6 +48,26 @@ go mod download
 
 # Verify installation
 make test
+```
+
+### Environment Isolation
+
+The project uses the `BRAGDOC_HOME` environment variable to separate development data from the official install (`~/.bragdoc`). We recommend using [direnv](https://direnv.net/) to manage this automatically:
+
+```bash
+# Copy the example and adjust if needed
+cp .envrc.example .envrc
+
+# Allow direnv to load the file
+direnv allow
+```
+
+This sets `BRAGDOC_HOME` to `.bragdoc` inside the project directory. When you leave the project folder, the variable is unset and `bragdoc` uses the default `~/.bragdoc` again.
+
+You can also set the variable manually:
+
+```bash
+export BRAGDOC_HOME=/path/to/dev/data
 ```
 
 ### Build the Project

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -80,11 +80,7 @@ func getDatabasePath(cfg *config.Config) string {
 		return expandPath(cfg.Database.Path)
 	}
 
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		homeDir = "."
-	}
-	return filepath.Join(homeDir, ".bragdoc", "bragdoc.db")
+	return filepath.Join(config.ResolveBragdocHome(), "bragdoc.db")
 }
 
 func expandPath(path string) string {

--- a/config/manager.go
+++ b/config/manager.go
@@ -30,16 +30,30 @@ type Manager struct {
 	viper      *viper.Viper
 }
 
-// NewManager creates a new configuration manager
-func NewManager() *Manager {
+// BragdocHomeEnv is the environment variable to override the default data directory.
+// When set, bragdoc uses its value instead of ~/.bragdoc.
+// This follows Viper's convention with the BRAGDOC prefix.
+const BragdocHomeEnv = "BRAGDOC_HOME"
+
+// ResolveBragdocHome returns the bragdoc data directory following Viper's
+// precedence: env var (BRAGDOC_HOME) > default (~/.bragdoc).
+// The config file itself lives inside this directory, so this resolution
+// must happen before Viper loads the config file.
+func ResolveBragdocHome() string {
+	if envHome := os.Getenv(BragdocHomeEnv); envHome != "" {
+		return expandHomeDir(envHome)
+	}
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		// Fallback to current directory if home is not available
 		homeDir = "."
 	}
+	return filepath.Join(homeDir, ".bragdoc")
+}
 
+// NewManager creates a new configuration manager
+func NewManager() *Manager {
 	return &Manager{
-		configDir: filepath.Join(homeDir, ".bragdoc"),
+		configDir: ResolveBragdocHome(),
 		viper:     viper.New(),
 	}
 }

--- a/internal/command/brag/helpers.go
+++ b/internal/command/brag/helpers.go
@@ -2,10 +2,9 @@ package brag
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
+	"github.com/vagnerclementino/bragdoc/config"
 )
 
 // requiresInitialization returns a PreRunE function that checks if bragdoc is initialized
@@ -23,22 +22,6 @@ Example:
 
 // isInitialized checks if bragdoc has been initialized by looking for the config directory
 func isInitialized() bool {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return false
-	}
-
-	configDir := filepath.Join(homeDir, ".bragdoc")
-	dbPath := filepath.Join(configDir, "bragdoc.db")
-
-	// Check if both config directory and database exist
-	if _, err := os.Stat(configDir); os.IsNotExist(err) {
-		return false
-	}
-
-	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
-		return false
-	}
-
-	return true
+	m := config.NewManager()
+	return m.IsInitialized()
 }

--- a/internal/command/doc/helpers.go
+++ b/internal/command/doc/helpers.go
@@ -2,10 +2,9 @@ package doc
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
+	"github.com/vagnerclementino/bragdoc/config"
 )
 
 // requiresInitialization returns a PreRunE function that checks if bragdoc is initialized
@@ -23,22 +22,6 @@ Example:
 
 // isInitialized checks if bragdoc has been initialized by looking for the config directory
 func isInitialized() bool {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return false
-	}
-
-	configDir := filepath.Join(homeDir, ".bragdoc")
-	dbPath := filepath.Join(configDir, "bragdoc.db")
-
-	// Check if both config directory and database exist
-	if _, err := os.Stat(configDir); os.IsNotExist(err) {
-		return false
-	}
-
-	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
-		return false
-	}
-
-	return true
+	m := config.NewManager()
+	return m.IsInitialized()
 }

--- a/internal/command/tag/helpers.go
+++ b/internal/command/tag/helpers.go
@@ -2,10 +2,9 @@ package tag
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
+	"github.com/vagnerclementino/bragdoc/config"
 )
 
 // requiresInitialization returns a PreRunE function that checks if bragdoc is initialized
@@ -23,22 +22,6 @@ Example:
 
 // isInitialized checks if bragdoc has been initialized by looking for the config directory
 func isInitialized() bool {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return false
-	}
-
-	configDir := filepath.Join(homeDir, ".bragdoc")
-	dbPath := filepath.Join(configDir, "bragdoc.db")
-
-	// Check if both config directory and database exist
-	if _, err := os.Stat(configDir); os.IsNotExist(err) {
-		return false
-	}
-
-	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
-		return false
-	}
-
-	return true
+	m := config.NewManager()
+	return m.IsInitialized()
 }


### PR DESCRIPTION
## Summary

Adiciona suporte à variável de ambiente `BRAGDOC_HOME` para configurar o diretório de dados, permitindo isolar o ambiente de desenvolvimento do oficial.

## Changes

- Add `ResolveBragdocHome()` em `config/manager.go` que checa `BRAGDOC_HOME` antes de usar `~/.bragdoc`
- Centraliza resolução de path removendo lógica duplicada dos helpers de brag/doc/tag
- Add `.envrc.example` para novos contribuidores
- Update `CONTRIBUTING.md` com documentação de isolamento de ambiente

## Usage

```bash
# Via direnv (recomendado)
cp .envrc.example .envrc
direnv allow

# Ou manualmente
export BRAGDOC_HOME=/path/to/dev/data
```

Closes #14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `BRAGDOC_HOME` environment variable to isolate development data from the default installation directory.

* **Documentation**
  * Updated setup guide with `direnv` prerequisite and instructions for configuring environment isolation during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->