### PR TITLE
feat: add bragdoc reset command

### DIFF
--- a/config/manager.go
+++ b/config/manager.go
@@ -221,6 +221,11 @@ func (m *Manager) GetConfigPath() string {
 	return filepath.Join(m.configDir, "config.yaml")
 }
 
+// GetConfigDir returns the path to the bragdoc configuration directory.
+func (m *Manager) GetConfigDir() string {
+	return m.configDir
+}
+
 // GetDatabasePath returns the path to the database file
 func (m *Manager) GetDatabasePath() string {
 	return filepath.Join(m.configDir, "bragdoc.db")

--- a/internal/command/reset.go
+++ b/internal/command/reset.go
@@ -1,0 +1,58 @@
+package command
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/vagnerclementino/bragdoc/config"
+)
+
+// NewResetCmd creates a new command for resetting bragdoc to a clean state.
+func NewResetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "reset",
+		Short: "Reset bragdoc to a clean state",
+		Long: `Reset bragdoc by removing the configuration directory and database.
+This deletes all data including users, brags, tags, and configuration.
+After reset, you can run 'bragdoc init' to start fresh.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runReset(cmd)
+		},
+	}
+
+	cmd.Flags().Bool("force", false, "Skip confirmation prompt")
+
+	return cmd
+}
+
+func runReset(cmd *cobra.Command) error {
+	configManager := config.NewManager()
+
+	if !configManager.IsInitialized() {
+		fmt.Println("ℹ️  Bragdoc is not initialized. Nothing to reset.")
+		return nil
+	}
+
+	force, _ := cmd.Flags().GetBool("force")
+
+	configDir := configManager.GetConfigDir()
+	fmt.Printf("⚠️  This will delete all bragdoc data:\n")
+	fmt.Printf("   📁 %s\n", configDir)
+
+	if !force {
+		fmt.Print("\nAre you sure? (y/N): ")
+		var answer string
+		if _, err := fmt.Scanln(&answer); err != nil || (answer != "y" && answer != "Y") {
+			fmt.Println("❌ Reset cancelled.")
+			return nil
+		}
+	}
+
+	if err := os.RemoveAll(configDir); err != nil {
+		return fmt.Errorf("failed to remove bragdoc data: %w", err)
+	}
+
+	fmt.Println("✅ Bragdoc has been reset. Run 'bragdoc init' to start fresh.")
+	return nil
+}

--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -31,6 +31,7 @@ build their own "Brag Documents" to track and showcase their professional achiev
 		tag.NewTagCmd(tagService),
 		doc.NewDocCmd(docService, bragService, tagService),
 		NewInitCmd(),
+		NewResetCmd(),
 		NewVersionCmd(),
 		NewDoctorCmd(), // Hidden command for debugging
 	)


### PR DESCRIPTION
Closes #24 

Add a `bragdoc reset` command that removes the `~/.bragdoc/` directory (config + database), allowing users to start fresh with \`bragdoc init\`.

Changes:
- `internal/command/reset.go` — new reset command with `--force` flag
- `internal/command/root.go` — register the reset command
- `config/manager.go` — expose `GetConfigDir()` method

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Other (please describe):

## Issue Link

https://github.com/vagnerclementino/bragdoc/issues/24

## Documentation

- [ ] Did you update the readme of the project?
- [ ] Did you add/update the swagger documentation?
- [ ] Did you add/update the postman documentation?

## Test

- [ ] Did you add/update unit tests?
- [ ] Did you add mutation tests?
- [ ] Did you add integration tests?

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings (Sonar)

## If something goes wrong with these changes, we must:

- [x] Revert this PR
- [ ] Disable the feature toggle (Which Feature Toggle?)
- [ ] Other (please, specify)"